### PR TITLE
Add wp-plugin-cc-gutenberg-blocks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "wp-theme-creativecommons.org"]
 	path = wp-theme-creativecommons.org
 	url = git@github.com:creativecommons/wp-theme-creativecommons.org.git
+[submodule "wp-plugin-cc-gutenberg-blocks"]
+	path = wp-plugin-cc-gutenberg-blocks
+	url = https://github.com/creativecommons/wp-plugin-cc-gutenberg-blocks.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,3 +83,15 @@ Once you are logged in with your admin user (above), you can access the WordPres
 ### Activate CC theme and plugins
 
 From the WordPress admin area, you can activate the Creative Commons WordPress theme and plugins.
+
+### Developing Gutenberg blocks
+
+This project contains the `wp-plugin-cc-gutenberg-blocks` project as a Git submodule. Do the following, if you would like to develop CC Gutenberg blocks in the context of `project_creativecommons.org`.
+
+1. make sure you have completed all of the above steps so the Docker Compose project is running
+2. open a new teminal
+3. change directory `cd` into `wp-plugin-cc-gutenberg-blocks`
+4. run `npm install` to install dependencies
+5. run `npm start` to start the Gutenberg block development project
+
+From there, you can make changes to files in `wp-plugin-cc-gutenberg-blocks/src/` that will automatically build. Commits made to that submodule can be pushed to branches in the upstream project as well.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing
+
+There are many ways to contribute to this project, such as testing, design, and development.
+
+
+## Development
+
+This section provides information for people who are interested in contributing code.
+
+### Development dependencies
+Make sure you have installed [Docker](https://docs.docker.com/get-docker/) and `docker-compose` for your operating system prior to following these instructions.
+
+### Initialize Git submodules
+
+This project consists of several components, such as WordPress themes, that are developed in their own Git repositories. If you have already cloned this project's code, make sure the Git sub-modules are activated by running the following command.
+
+```sh
+git submodule update --init
+```
+
+Alternatively, you can initialize the submodules when you clone the repository with the following command.
+
+```sh
+git clone --recursive
+```
+
+## Environment variables
+
+There are several environment variables required to run the `docker-compose` command. Copy the `.env.example` to `.env` and override the variables if needed. The defaults should work fine.
+
+### Changing database
+
+The `.env` file should contain a variable called `DATABASE` that is used to choose which database to use for development (`mysql` or `mariadb`).
+
+If you change the value of the `DATABASE` variable at any time during development, you will need to remove the old database volume in order and rebuild the images to prevent errors.
+
+1. list all Docker volumes to find the relevant volume
+    - `docker volume ls`
+2. remove the volume
+    - `docker volume rm <volume-id>`
+3. rebuild the docker image
+    - `docker-compose up --build -d`
+
+### Run the development server
+
+Once you have installed the above development dependencies, you can run the following commands from within this project directory.
+
+#### Start the server
+
+```sh
+docker-compose up
+```
+
+#### Stop the server
+
+```sh
+docker-compose down
+```
+
+### Access WordPress
+
+After starting the server, you should be able to access WordPress at http://localhost:8080
+
+### Install WordPres (first-time)
+
+If you are starting the WordPress service for the first time, you will see the WordPress installation wizard. Complete the installation process and make note of your username and password so that you can log in (below).
+
+
+### Log in to WordPress
+
+With the development server running, log in to the local WordPress with the login credentials you created during the WordPress installation.
+
+Note: you will need to visit http://localhost:8080/wp-login.php
+
+
+### Access the WordPress admin area
+
+Once you are logged in with your admin user (above), you can access the WordPress admin area:
+
+- http://localhost:8080/wp-admin/
+
+
+### Activate CC theme and plugins
+
+From the WordPress admin area, you can activate the Creative Commons WordPress theme and plugins.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Project to manage technical implementation of [creativecommons.org](https://creativecommons.org/) (primary website)
 
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ## Status
 
@@ -42,105 +45,21 @@ Infrastructure Management is handled by:
 [code_of_conduct]:https://creativecommons.github.io/community/code-of-conduct/
 [reporting_guide]:https://creativecommons.github.io/community/code-of-conduct/enforcement/
 
-
-## Contributing
-
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) and [Contributors ✨](#contributors-), below.
-
-
-## Prerequisites
-
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
-
-
-## Development
-
-
-### Development dependencies
-Make sure you have installed [Docker](https://docs.docker.com/get-docker/) and `docker-compose` for your operating system prior to following these instructions.
-
-
-### Initialize Git submodules
-
-This project consists of several components, such as WordPress themes, that are developed in their own Git repositories. If you have already cloned this project's code, make sure the Git sub-modules are activated by running the following command.
-
-```sh
-git submodule update --init
-```
-
-Alternatively, you can initialize the submodules when you clone the repository with the following command.
-
-```sh
-git clone --recursive
-```
-
-## Environment variables
-
-There are several environment variables required to run the `docker-compose` command. Copy the `.env.example` to `.env` and override the variables if needed. The defaults should work fine.
-
-### Changing database
-
-The `.env` file should contain a variable called `DATABASE` that is used to choose which database to use for development (`mysql` or `mariadb`).
-
-If you change the value of the `DATABASE` variable at any time during development, you will need to remove the old database volume in order and rebuild the images to prevent errors.
-
-1. list all Docker volumes to find the relevant volume
-    - `docker volume ls`
-2. remove the volume
-    - `docker volume rm <volume-id>`
-3. rebuild the docker image
-    - `docker-compose up --build -d`
-
-### Run the development server
-
-Once you have installed the above development dependencies, you can run the following commands from within this project directory.
-
-
-#### Start the server
-
-```sh
-docker-compose up
-```
-
-#### Stop the server
-
-```sh
-docker-compose down
-```
-
-
-### Access WordPress
-
-After starting the server, you should be able to access WordPress at http://localhost:8080
-
-### Install WordPres (first-time)
-
-If you are starting the WordPress service for the first time, you will see the WordPress installation wizard. Complete the installation process and make note of your username and password so that you can log in (below).
-
-
-### Log in to WordPress
-
-With the development server running, log in to the local WordPress with the login credentials you created during the WordPress installation.
-
-Note: you will need to visit http://localhost:8080/wp-login.php
-
-
-### Access the WordPress admin area
-
-Once you are logged in with your admin user (above), you can access the WordPress admin area:
-
-- http://localhost:8080/wp-admin/
-
 ## License
 
 - [`LICENSE`](LICENSE) (Expat/[MIT][mit] License)
 
+## Contributing
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) and [Contributors ✨](#contributors-), below.
+
+
 [mit]: http://www.opensource.org/licenses/MIT "The MIT License | Open Source Initiative"
 
 
-## Contributors ✨
+### Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 
@@ -160,5 +79,3 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
-
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       #- ./config/php.conf.ini:/usr/local/etc/php/conf.d/conf.ini
       - ./wp-app:/var/www/html # Full wordpress project
       # Plugin development
-      - ./wp-plugin-cc-gutenberg-blocks/:/var/www/html/wp-content/plugins/wp-plugin-cc-gutenberg-blocks
+      - ./wp-plugin-cc-gutenberg-blocks/dist/:/var/www/html/wp-content/plugins/wp-plugin-cc-gutenberg-blocks
       # Theme development
       - ./creativecommons-base/:/var/www/html/wp-content/themes/creativecommons-base
       - ./wp-theme-creativecommons.org/:/var/www/html/wp-content/themes/wp-theme-creativecommons.org

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
     volumes:
       #- ./config/php.conf.ini:/usr/local/etc/php/conf.d/conf.ini
       - ./wp-app:/var/www/html # Full wordpress project
-      #- ./plugin-name/trunk/:/var/www/html/wp-content/plugins/plugin-name # Plugin development
+      # Plugin development
+      - ./wp-plugin-cc-gutenberg-blocks/:/var/www/html/wp-content/plugins/wp-plugin-cc-gutenberg-blocks
       # Theme development
       - ./creativecommons-base/:/var/www/html/wp-content/themes/creativecommons-base
       - ./wp-theme-creativecommons.org/:/var/www/html/wp-content/themes/wp-theme-creativecommons.org


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes #91  by @brylie

Allowing Gutenberg block development by adding `wp-plugin-cc-gutenberg-blocks` as Git submodule.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
