### PR TITLE
Better configure WordPress behind dispatch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,20 +130,26 @@ The commands above will create a variety of docker services:
 
 ### Install WordPres (first-time)
 
-If you are starting the WordPress service for the first time, you will see the WordPress installation wizard. Complete the installation process and make note of your username and password so that you can log in (below).
+If you are starting the WordPress service for the first time, you will see the
+WordPress installation wizard:
+- [127.0.0.1:8000/wp-admin/install.php](http://127.0.0.1:8000/wp-admin/install.php)
+
+Complete the installation process and make note of your username and password
+so that you can log in (below).
 
 
 ### Log in to WordPress
 
-With the development server running, log in to the local WordPress with the login credentials you created during the WordPress installation.
-
-Note: you will need to visit http://127.0.0.1:8080/wp-login.php
+With the development server running, log in to the local WordPress with the
+login credentials you created during the WordPress installation:
+- [127.0.0.1:8000/wp-login.php](http://127.0.0.1:8000/wp-login.php).
 
 
 ### Access the WordPress admin area
 
-Once you are logged in with your admin user (above), you can access the WordPress admin area:
-- [127.0.0.1:8000/wp-admin/](http://127.0.0.1:8000/wp-admin/) (or directly on **wordpress** host via port 8002)
+Once you are logged in with your admin user (above), you can access the
+WordPress admin area:
+- [127.0.0.1:8000/wp-admin/](http://127.0.0.1:8000/wp-admin/)
 
 
 ### Activate CC theme and plugins

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,10 @@ services:
       WORDPRESS_DB_NAME: "${DB_NAME:-wordpress_db}"
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: "${DB_ROOT_PASSWORD:-db_password}"
+      WORDPRESS_CONFIG_EXTRA: |
+        # Use dispatch port by default
+        define('WP_HOME', 'http://127.0.0.1:8000');
+        define('WP_SITEURL', 'http://127.0.0.1:8000');
     depends_on:
       - database
     networks:


### PR DESCRIPTION
## Fixes
Fixes #168 
- #168

## Description
Better configure WordPress behind dispatch

(Merge #169 first)

## Tests
Redirect location uses proper port:
```
curl -I http://127.0.0.1:8000/wp-admin/
```
```
HTTP/1.1 302 Found
Server: nginx/1.21.4
Date: Tue, 23 Nov 2021 18:16:27 GMT
Content-Type: text/html; charset=UTF-8
Connection: keep-alive
X-Powered-By: PHP/7.4.26
Expires: Wed, 11 Jan 1984 05:00:00 GMT
Cache-Control: no-cache, must-revalidate, max-age=0
X-Redirect-By: WordPress
Location: http://127.0.0.1:8000/wp-login.php?redirect_to=http%3A%2F%2F127.0.0.1%2Fwp-admin%2F&reauth=1
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
