### PR TITLE
Remove faq submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "wp-plugin-creativecommons-website"]
 	path = wp-plugin-creativecommons-website
 	url = https://github.com/creativecommons/wp-plugin-creativecommons-website.git
-[submodule "faq"]
-	path = faq
-	url = https://github.com/creativecommons/faq
 [submodule "mp"]
 	path = mp
 	url = https://github.com/creativecommons/mp

--- a/config/dispatch_nginx/dispatch.conf
+++ b/config/dispatch_nginx/dispatch.conf
@@ -16,9 +16,6 @@ server {
     }
 
     # misc
-    location /faq {
-        root   /usr/share/nginx/html;
-    }
     location /platform/toolkit {
         root   /usr/share/nginx/html;
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,13 +80,13 @@ services:
       context: ./database/${DATABASE:-mariadb}
     container_name: project_creativecommons-database
     ports:
-      - "3307:3306"
+      - "3306:3306"
     volumes:
       #- ./wp-data:/docker-entrypoint-initdb.d
       - db_data:/var/lib/mysql
     environment:
       MYSQL_DATABASE: "${DB_NAME:-wordpress_db}"
-      MYSQL_USER: creative
+      MYSQL_USER: root
       MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASSWORD:-db_password}"
     networks:
       - backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       # config
       - ./config/dispatch_nginx:/etc/nginx/conf.d:ro
       # content (misc)
-      - ./faq/faq:/usr/share/nginx/html/faq:ro
       - ./mp/docs:/usr/share/nginx/html/platform/toolkit:ro
 
   legaltools:
@@ -81,13 +80,13 @@ services:
       context: ./database/${DATABASE:-mariadb}
     container_name: project_creativecommons-database
     ports:
-      - "3306:3306"
+      - "3307:3306"
     volumes:
       #- ./wp-data:/docker-entrypoint-initdb.d
       - db_data:/var/lib/mysql
     environment:
       MYSQL_DATABASE: "${DB_NAME:-wordpress_db}"
-      MYSQL_USER: root
+      MYSQL_USER: creative
       MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASSWORD:-db_password}"
     networks:
       - backend


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Closes #174 by @brylie 

## Description
Removes the FAQs submodule from `project_creativecommons.org` repository.
 - [x] remove faq Git submodule
 - [x] remove FAQ configuration from the project (such as Docker Compose reverse-proxy service)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
