### PR TITLE
Adding WordPress url back of proper navigation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,10 @@ services:
       WORDPRESS_DB_NAME: "${DB_NAME:-wordpress_db}"
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: "${DB_ROOT_PASSWORD:-db_password}"
+      WORDPRESS_CONFIG_EXTRA: |
+        # Use dispatch port by default
+        define('WP_HOME', 'http://127.0.0.1:8000');
+        define('WP_SITEURL', 'http://127.0.0.1:8000');
     depends_on:
       - database
     networks:


### PR DESCRIPTION
## Description
Adding the WordPress extra config back in the YML file. Without it, the app is not able to open the homepage url

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [ ] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.
