### PR TITLE
add wp-cli helper script and update documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
+# Database Variables
 DB_ROOT_PASSWORD=password
 DB_NAME=wordpress
-
-#here you can switch between mysql/mariadb
+# here you can switch between mysql/mariadb
 DATABASE=mariadb
+
+
+# Setup WordPress Vaiables
+WP_ADMIN_EMAIL=
+WP_ADMIN_USER=
+WP_ADMIN_PASS=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ docker-compose down
 
 ### WP CLI
 
-1. Ensure the docker services are running ([Star the server](start-the-server), above)
+1. Ensure the docker services are running ([Start the server](start-the-server), above)
 2. Simply run the helper script:
 ```
 ./setup-wordpress.sh
@@ -181,7 +181,7 @@ Alternatively, use the WordPress CLI to import the content. See the WordPress CL
 
 The content importer contains a menu called "CC". The CC menu is intended to represent the main navigation. It will also be served via the API for downstream projects like the CC Global Headers.
 
-Go to the Menus -> [Manage Locations](http://127.0.0.1:8000/wp-admin/nav-menus.php?action=locations) screen and make sure the CC menu is in the Main navigation location.
+Go to the Appearance -> Menus -> [Manage Locations](http://127.0.0.1:8000/wp-admin/nav-menus.php?action=locations) screen and make sure the CC menu is in the Main navigation location.
 
 #### Enable URL rewrites for clean API URLs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 There are many ways to contribute to this project, such as testing, design, and development.
 
-## Development
+## Development Setup
 
 This section provides information for people who are interested in contributing code.
 
@@ -57,11 +57,11 @@ The Git submodule projects are under active development. When the submodule code
 git submodule update --remote --merge
 ```
 
-## Environment variables
+### Environment variables
 
 There are several optional environment variables used in the `docker-compose.yml` file. If you need, you can copy the `.env.example` to `.env` and override the variables. Otherwise, the defaults should work fine.
 
-### Changing database
+#### Changing database
 
 The optional `.env` file may contain a variable called `DATABASE`. The value of `DATABASE` will determine which database is used for development (`mysql` or `mariadb`). By default, we use `mariadb` but you can change this to `mysql` if desired.
 
@@ -90,11 +90,11 @@ You can revert the change with:
 rm cc-legal-tools-data; git restore cc-legal-tools-data; git submodule update --init
 ```
 
-### Run the development server
+## Run the development server
 
 Once you have installed the above development dependencies, you can run the following commands from within this project directory.
 
-#### Start the server
+### Start the server
 
 Note: this step is handled automatically in the browser-based development environment.
 
@@ -109,13 +109,35 @@ The command above will create a variety of docker services:
 3. **phpmyadmin** ([127.0.0.1:8003](http://127.0.0.1:8003/))
 4. **composer**
 
-#### Stop the server
+### Stop the server
 
 ```sh
 docker-compose down
 ```
 
-### Install WordPress (first-time)
+## Setup WordPress (first-time)
+
+### WP CLI
+
+1. Ensure the docker services are running ([Star the server](start-the-server), above)
+2. Simply run the helper script:
+```
+./setup-wordpress.sh
+```
+
+If you want to run WPI CLI commands manually, the following alias willmake it much easier:
+
+``` sh
+alias wp="docker-compose run --rm wordpress-cli --url='http://127.0.0.1:8000'"
+```
+
+Verify the alias:
+
+```sh
+wp --info
+```
+
+### Web GUI
 
 If you are starting the WordPress service for the first time, you will see the
 WordPress installation wizard:
@@ -127,27 +149,27 @@ so that you can log in (below).
 
 Alternatively, see the WordPress CLI section below for an example of how to install WordPress via the command line.
 
-### Log in to WordPress
+#### Log in to WordPress
 
 With the development server running, log in to the local WordPress with the
 login credentials you created during the WordPress installation:
 
 - [127.0.0.1:8000/wp-login.php](http://127.0.0.1:8000/wp-login.php).
 
-### Access the WordPress admin area
+#### Access the WordPress admin area
 
 Once you are logged in with your admin user (above), you can access the
 WordPress admin area:
 
 - [127.0.0.1:8000/wp-admin/](http://127.0.0.1:8000/wp-admin/)
 
-### Activate CC theme and plugins
+#### Activate CC theme and plugins
 
 From the WordPress admin area, you can activate the Creative Commons WordPress child theme from the [Theme Settings](http://127.0.0.1:8000/wp-admin/themes.php) and [Plugins](http://127.0.0.1:8000/wp-admin/plugins.php) pages respectively. Note, some plugins may be automatically enabled by our Docker compose service.
 
 The child theme is called `creativecommons.org Child theme`.
 
-### Import staging content
+#### Import staging content
 
 We have prepared some pre-existing content based on the desired page and URL structure for the new Creative Commons website, which is located in the `content-import` folder in the file `staging-content-import.xml`.
 
@@ -155,69 +177,19 @@ The WordPress documentation contains an article describing [how to import conten
 
 Alternatively, use the WordPress CLI to import the content. See the WordPress CLI instructions below.
 
-### Ensure CC menu is in main navigation location
+#### Ensure CC menu is in main navigation location
 
 The content importer contains a menu called "CC". The CC menu is intended to represent the main navigation. It will also be served via the API for downstream projects like the CC Global Headers.
 
 Go to the Menus -> [Manage Locations](http://127.0.0.1:8000/wp-admin/nav-menus.php?action=locations) screen and make sure the CC menu is in the Main navigation location.
 
-### Enable URL rewrites for clean API URLs
+#### Enable URL rewrites for clean API URLs
 
 Visit the [Permalink Settings](http://127.0.0.1:8000/wp-admin/options-permalink.php) page to enable clean URLs, such as might be used by external sites and services.
 
 Alternatively, see the WordPress CLI section below for an example of how to enable clean URLs via command line.
 
-### Working with the WordPress CLI
-
-The development environment contains a [WordPress CLI](https://wp-cli.org/) container that may prove useful for interacting with WordPress from the shell. Further details about specific WP CLI commands can be found in the [WP-CLI Handbook](https://make.wordpress.org/cli/handbook/).
-
-Use the following to send commands to the `wordpress-cli` Docker container:
-
-```sh
-docker-compose run --rm wordpress-cli
-```
-
-#### Create an alias for the WordPress CLI container
-
-Optionally, add the following alias to make it easier to interact with the WordPress CLI.
-
-``` sh
-alias wp="docker-compose run --rm wordpress-cli"`
-```
-
-Verify the alias:
-
-```sh
-wp --info
-```
-
-### Install WordPress
-
-We can install WordPress and create the initial admin user with a single command.
-
-Replace `YOUR_USERNAME` and `YOUR_EMAIL` with the appropriate values in the command below.
-
-```sh
-wp core install --url='http://127.0.0.1:8000' --title='CC Dev' --admin-user='YOUR_USERNAME' --admin_email='YOUR_EMAIL'
-```
-
-#### Import content
-
-The following WordPress CLI command can be used to import content, such as the `staging-content-import.xml`
-
-``` sh
-wp import  content-import/staging-content-import.xml --authors=create
-```
-
-#### Enable clean URLs
-
-The following command will set up clean URLs, such as may be needed by downstream sites or services.
-
-``` sh
-wp rewrite structure '/%postname%'
-```
-
-### Developing Gutenberg blocks
+## Developing Gutenberg blocks
 
 This project contains the `wp-plugin-cc-gutenberg-blocks` project as a Git submodule. Do the following, if you would like to develop CC Gutenberg blocks in the context of `project_creativecommons.org`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ docker-compose down
 
 ### WP CLI
 
-1. Ensure the docker services are running ([Start the server](start-the-server), above)
+1. Ensure the docker services are running ([Start the server](#start-the-server), above)
 2. Simply run the helper script:
 ```
 ./setup-wordpress.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
     volumes:
       - wp_data:/var/www/html
       - db_data:/var/lib/mysql
+      - ./content-import:/var/www/html/content-import
     networks:
       - backend
 

--- a/setup-wordpress.sh
+++ b/setup-wordpress.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+set -o errexit
+set -o errtrace
+set -o nounset
+
+source .env
+
+wp() {
+    docker-compose run --rm wordpress-cli \
+        wp --url='http://127.0.0.1:8000' "${@}"
+}
+
+printf "\e[1m\e[7m %-80s\e[0m\n" 'WP CLI info'
+wp --info
+echo
+
+printf "\e[1m\e[7m %-80s\e[0m\n" 'Install WordPress'
+if [[ -n "${WP_ADMIN_EMAIL}" ]] && [[ -n "${WP_ADMIN_EMAIL}" ]] \
+    && [[ -n "${WP_ADMIN_EMAIL}" ]]
+then
+    echo "       admin email: ${WP_ADMIN_EMAIL}"
+    echo "        admin user: ${WP_ADMIN_USER}"
+    echo "    admin password: ${WP_ADMIN_PASS}"
+else
+    echo 'The following variables must be set in .env (see .env.example):'
+    echo '    WP_ADMIN_EMAIL'
+    echo '    WP_ADMIN_USER'
+    echo '    WP_ADMIN_PASS'
+fi
+echo
+if wp --no-color --quiet core is-installed &> /dev/null
+then
+    echo 'no-op: already installed'
+else
+    wp core install \
+        --title='CC Dev' \
+        --admin_email="${WP_ADMIN_EMAIL}" \
+        --admin_user="${WP_ADMIN_USER}" \
+        --admin_password="${WP_ADMIN_PASS}" \
+        --skip-email
+fi
+echo
+
+printf "\e[1m\e[7m %-80s\e[0m\n" 'Enable post name permalinks'
+# The following complex command includes `cat` due to an apparent bug in
+# macOS grep
+if wp --no-color --quiet rewrite list 2> /dev/null | cat \
+    | grep -qF 'No rewrite rules.'
+then
+    wp rewrite structure --hard '/%postname%'
+else
+    echo 'no-op: rewrite rules exist'
+fi
+echo
+
+printf "\e[1m\e[7m %-80s\e[0m\n" 'Activate CC site plugin'
+plugin='wp-plugin-creativecommons-website'
+if wp --no-color --quiet plugin is-active "${plugin}" &> /dev/null
+then
+    echo "no-op: ${plugin} is already active"
+else
+    wp plugin activate "${plugin}"
+fi
+unset plugin
+echo
+
+printf "\e[1m\e[7m %-80s\e[0m\n" 'Install WordPress Importer plugin'
+plugin='wordpress-importer'
+if wp --no-color --quiet plugin is-active "${plugin}" &> /dev/null
+then
+    echo "no-op: ${plugin} is already installed & active"
+else
+    wp plugin install --activate "${plugin}"
+fi
+unset plugin
+echo
+
+printf "\e[1m\e[7m %-80s\e[0m\n" 'Activate creativecommons.org Child theme'
+theme="wp-theme-creativecommons.org"
+if wp --no-color --quiet theme is-active "${theme}" &> /dev/null
+then
+    echo "no-op: ${theme} is already active"
+else
+    echo "theme: ${theme}"
+    wp theme activate "${theme}"
+fi
+unset theme
+echo
+
+printf "\e[1m\e[7m %-80s\e[0m\n" 'Import content'
+# Test the first and last wp:post_id from import file
+# - excluding attachments, which don't seem to work
+# - this is fragile and will probably break if the import file is updated
+# - troubleshoot with:
+#       wp post-type list
+#       wp post list --post_type=attachment,nav_menu_item,page \
+#           --fields=ID,post_type,post_title,post_name,post_date,post_status
+if wp --no-color --quiet post exists 63046 &> /dev/null \
+    && wp post --no-color --quiet exists 63038 &> /dev/null
+then
+    echo 'no-op: posts from import already exist'
+else
+    wp import content-import/staging-content-import.xml --authors=create
+fi
+echo
+
+printf "\e[1m\e[7m %-80s\e[0m\n" 'Assign menu locations'
+if wp --no-color --quiet menu list 2> /dev/null | grep -F cc \
+        | grep -qF main-navigation \
+    && wp --no-color --quiet menu list 2> /dev/null | grep -F cc \
+        | grep -qF main-menu-mobile
+then
+    echo 'no-op: menu locations already assigned'
+else
+    wp menu location assign cc main-navigation
+    wp menu location assign cc main-menu-mobile
+fi
+echo
+
+printf "\e[1m\e[7m %-80s\e[0m\n" \
+    'Show maintenance mode status to expose any PHP Warnings'
+wp maintenance-mode status


### PR DESCRIPTION
## Description
This builds on the previous work to create a helper script that does all of the initial WordPress setup.
- add `setup-wordpress.sh`
  - includes tests so it can be run repeatedly without issue
  - includes info output and exposes PHP warnings
- update `docker-compose.yml`
  - add `content-import` volume to `wordpress-cli` docker service so import can import
- update `CONTRIBUTING.md`
  - improve (I hope!) heading levels
  - update WP CLI documentation

For comparison:
- Current/`main` [`CONTRIBUTING.md`](https://github.com/creativecommons/project_creativecommons.org/blob/2affef5e0b8ed80517d319dc70b1f7136c538a59/CONTRIBUTING.md)
- Proposed/PR [`CONTRIBUTING.md`](https://github.com/creativecommons/project_creativecommons.org/blob/90334b58d63892efcc53c48985e62a6c261ccb55/CONTRIBUTING.md)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
